### PR TITLE
Update PlacesScreen for better menu text viewing

### DIFF
--- a/Photoview/Screens/Places/PlacesScreen.swift
+++ b/Photoview/Screens/Places/PlacesScreen.swift
@@ -124,7 +124,7 @@ struct PlacesScreen: View {
         NavigationView {
             ZStack {
                 PlacesMapView(markers: markers, selectedAnnotation: $selectedAnnotation)
-                    .ignoresSafeArea()
+                    .edgesIgnoringSafeArea(.top)
                 NavigationLink(destination: ClusterDetailsView(markers: clusterMarkers, location: clusterLocation), isActive: clusterNavigationActive, label: { EmptyView() })
             }
         }


### PR DESCRIPTION
Updated the PlacesScreen to only ignore the safe space on the top. Ignoring the safe space on the bottom makes the navigation bar's text very hard to read

![image](https://user-images.githubusercontent.com/17243132/219977665-792448ed-2c2d-40e8-af34-f64af569f48d.png)
